### PR TITLE
Currency type fix

### DIFF
--- a/src/components/reward/index.tsx
+++ b/src/components/reward/index.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import styled from "styled-components"
-import { Currency, RewardData } from "../../types"
+import { Currency, CurrencyStrictLegacy, RewardData } from "../../types"
 import { GenericTranslation } from "../translations"
 import { Reward } from "./wrapper"
 
@@ -24,7 +24,7 @@ export function Rewards(props: Props) {
 						amount={reward.amount}
 						type={reward.currency}
 						icon={props.icons && props.icons[reward.currency]}
-						description={props.translations[reward.currency]}
+						description={props.translations[reward.currency as CurrencyStrictLegacy]}
 					/>
 				))}
 			</Upgrade>

--- a/src/types/reward.ts
+++ b/src/types/reward.ts
@@ -15,6 +15,9 @@ export enum TeamCurrencyEnum {
 }
 export type TeamCurrency = keyof typeof TeamCurrencyEnum
 
-export type Currency = UserCurrency | TeamCurrency
+export type Currency = UserCurrency | TeamCurrency | string /* "string" here means: UUID of a character progression  */
+
+/* Only to be used in speciell locations where the hard coded currency values are to be referenced */
+export type CurrencyStrictLegacy = UserCurrency | TeamCurrency
 
 export type RewardIcons = Partial<Record<Currency, string>>


### PR DESCRIPTION
Allow 'string' as currency as in node-utils. Option for strictness where needed.